### PR TITLE
Update extension to 0.7.5 (#13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "amxxpawn-language",
     "displayName": "AMXXPawn Language",
     "description": "AMXXPawn Language Service",
-    "version": "0.7.4",
+    "version": "0.7.5",
     "publisher": "KliPPy",
     "license": "GPL-3.0",
     "icon": "images/extension-logo.png",

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -10,7 +10,7 @@ let diagnosticCollection: VSC.DiagnosticCollection;
 
 export function activate(ctx: VSC.ExtensionContext) {
     const serverModulePath = ctx.asAbsolutePath(Path.join('build', 'server', 'server.js'));
-    const debugOptions = { execArgv: ["--nolazy", "--debug=5858"] };
+    const debugOptions = { execArgv: ['--nolazy', '--inspect=5858'] };
 
     const serverOptions: VSCLC.ServerOptions = {
         run: {

--- a/syntaxes/amxxpawn.tmLanguage
+++ b/syntaxes/amxxpawn.tmLanguage
@@ -101,7 +101,7 @@
         </dict>
         <dict>
             <key>match</key>
-            <string>\b(true|false|__DATE__|__TIME__|__LINE__|__BINARY_PATH__|__BINARY_NAME__|cellbits|cellmax|cellmin|__Pawn|debug)\b</string>
+            <string>\b(true|false|__DATE__|__TIME__|__LINE__|__FILE__|__BINARY_PATH__|__BINARY_NAME__|__BINARY__|cellbits|cellmax|cellmin|__Pawn|debug)\b</string>
             <key>name</key>
             <string>constant.language.amxxpawn</string>
         </dict>


### PR DESCRIPTION
* Fixed error: "Starting client failed." for Visual Studio Code 1.25.1+ - compability fix.

Why? Read this from VSCode docs:
// The debug options for the server
    // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging

* Update extension version

* Added new consts from AMXX
(https://github.com/alliedmodders/amxmodx/commit/582df637ce756d1e54c5e69775dba41bf6b98f0b)